### PR TITLE
Enhance prompt usability for kakoune-acp CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ kakoune-acp prompt \
 
 The `prompt` subcommand collects the agent's streamed updates, renders them into a human friendly transcript, and can optionally emit Kakoune commands (`--output kak-commands`) or send them directly back to the editor (`--send-to-kak`). When invoked from `%sh{}` the current `kak_session` and `kak_client` environment variables are honoured automatically.
 
+Prompts can come from `--prompt`, `--prompt-file`, or piped standard input. When stdin is interactive, the command now reminds you to specify one of those sources instead of waiting indefinitely. You can repeat `--context` or `--context-file` to attach additional snippets that help the agent answer your request.
+
 ### 3. Inspect or stop the daemon
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 use std::{ffi::OsString, path::PathBuf};
 
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum, ValueHint};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Agent Client Protocol bridge for Kakoune")]
@@ -44,14 +44,17 @@ pub struct PromptOptions {
     #[arg(long)]
     pub socket: Option<PathBuf>,
     /// Explicit prompt text. If omitted, stdin is read instead.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "prompt_file")]
     pub prompt: Option<String>,
     /// Read the prompt from a file on disk.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "prompt", value_hint = ValueHint::FilePath)]
     pub prompt_file: Option<PathBuf>,
     /// Additional snippets of context that should be appended to the prompt.
     #[arg(long)]
     pub context: Vec<String>,
+    /// Read additional context snippets from files.
+    #[arg(long = "context-file", value_hint = ValueHint::FilePath)]
+    pub context_files: Vec<PathBuf>,
     /// Kakoune session to send responses back to.
     #[arg(long, env = "kak_session")]
     pub session: Option<String>,


### PR DESCRIPTION
## Summary
- prevent conflicting prompt flags and add a context-file option for the prompt subcommand
- surface a friendlier error when no prompt is supplied on interactive terminals and label rendered context snippets
- document the new prompt input and context options in the README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68e073e9f2ac83228f239c1bfb1dae0f