### PR TITLE
Add integration tests using mock ACP agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +158,17 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bytes"
@@ -217,10 +244,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "event-listener"
@@ -242,6 +291,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "futures"
@@ -333,6 +388,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,10 +440,12 @@ version = "0.1.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "clap",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
@@ -394,6 +463,12 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -441,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -517,6 +592,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +635,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -585,6 +693,19 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "ryu"
@@ -735,6 +856,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,10 +1007,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-link"
@@ -1033,3 +1200,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,16 @@ tokio = { version = "1.47", features = [
     "sync",
     "signal",
     "io-std",
+    "time",
 ] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+tempfile = "3.13"
+
+[[bin]]
+name = "mock-acp-agent"
+path = "src/bin/mock_acp_agent.rs"

--- a/src/bin/mock_acp_agent.rs
+++ b/src/bin/mock_acp_agent.rs
@@ -1,0 +1,238 @@
+use std::{cell::Cell, time::Duration};
+
+use agent_client_protocol::{self as acp, Client};
+use anyhow::Result;
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::sleep,
+};
+use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
+
+struct MockAgent {
+    session_update_tx: mpsc::UnboundedSender<(acp::SessionNotification, oneshot::Sender<()>)>,
+    next_session_id: Cell<u64>,
+}
+
+impl MockAgent {
+    fn new(
+        session_update_tx: mpsc::UnboundedSender<(acp::SessionNotification, oneshot::Sender<()>)>,
+    ) -> Self {
+        Self {
+            session_update_tx,
+            next_session_id: Cell::new(0),
+        }
+    }
+
+    async fn send_update(
+        &self,
+        session_id: &acp::SessionId,
+        update: acp::SessionUpdate,
+    ) -> std::result::Result<(), acp::Error> {
+        let (tx, rx) = oneshot::channel();
+        self.session_update_tx
+            .send((
+                acp::SessionNotification {
+                    session_id: session_id.clone(),
+                    update,
+                    meta: None,
+                },
+                tx,
+            ))
+            .map_err(|_| acp::Error::internal_error())?;
+        rx.await.map_err(|_| acp::Error::internal_error())
+    }
+}
+
+fn summarize_prompt_blocks(blocks: &[acp::ContentBlock]) -> String {
+    let mut summary = Vec::new();
+    for block in blocks {
+        if let acp::ContentBlock::Text(text) = block {
+            if !text.text.trim().is_empty() {
+                summary.push(text.text.trim().to_string());
+            }
+        }
+    }
+    if summary.is_empty() {
+        "(no text provided)".to_string()
+    } else {
+        summary.join(" ")
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl acp::Agent for MockAgent {
+    async fn initialize(
+        &self,
+        _: acp::InitializeRequest,
+    ) -> std::result::Result<acp::InitializeResponse, acp::Error> {
+        Ok(acp::InitializeResponse {
+            protocol_version: acp::V1,
+            agent_capabilities: acp::AgentCapabilities::default(),
+            auth_methods: Vec::new(),
+            meta: None,
+        })
+    }
+
+    async fn authenticate(
+        &self,
+        _: acp::AuthenticateRequest,
+    ) -> std::result::Result<acp::AuthenticateResponse, acp::Error> {
+        Ok(acp::AuthenticateResponse::default())
+    }
+
+    async fn new_session(
+        &self,
+        _: acp::NewSessionRequest,
+    ) -> std::result::Result<acp::NewSessionResponse, acp::Error> {
+        let session_id = self.next_session_id.get();
+        self.next_session_id.set(session_id + 1);
+        Ok(acp::NewSessionResponse {
+            session_id: acp::SessionId(session_id.to_string().into()),
+            modes: None,
+            meta: None,
+        })
+    }
+
+    async fn prompt(
+        &self,
+        arguments: acp::PromptRequest,
+    ) -> std::result::Result<acp::PromptResponse, acp::Error> {
+        let session_id = arguments.session_id.clone();
+        let summary = summarize_prompt_blocks(&arguments.prompt);
+
+        self.send_update(
+            &session_id,
+            acp::SessionUpdate::AgentThoughtChunk {
+                content: format!("Thinking about: {summary}").into(),
+            },
+        )
+        .await?;
+
+        self.send_update(
+            &session_id,
+            acp::SessionUpdate::Plan(acp::Plan {
+                entries: vec![
+                    acp::PlanEntry {
+                        content: "Read the provided context".into(),
+                        priority: acp::PlanEntryPriority::High,
+                        status: acp::PlanEntryStatus::InProgress,
+                        meta: None,
+                    },
+                    acp::PlanEntry {
+                        content: "Draft a helpful response".into(),
+                        priority: acp::PlanEntryPriority::Medium,
+                        status: acp::PlanEntryStatus::Pending,
+                        meta: None,
+                    },
+                ],
+                meta: None,
+            }),
+        )
+        .await?;
+
+        self.send_update(
+            &session_id,
+            acp::SessionUpdate::AvailableCommandsUpdate {
+                available_commands: vec![acp::AvailableCommand {
+                    name: "apply_suggestion".into(),
+                    description: "Apply the generated response to the buffer".into(),
+                    input: Some(acp::AvailableCommandInput::Unstructured {
+                        hint: "Type edits that should be applied".into(),
+                    }),
+                    meta: None,
+                }],
+            },
+        )
+        .await?;
+
+        let tool_id = acp::ToolCallId("write_summary".into());
+        self.send_update(
+            &session_id,
+            acp::SessionUpdate::ToolCall(acp::ToolCall {
+                id: tool_id.clone(),
+                title: "Generate summary".into(),
+                kind: acp::ToolKind::Edit,
+                status: acp::ToolCallStatus::InProgress,
+                content: Vec::new(),
+                locations: Vec::new(),
+                raw_input: None,
+                raw_output: None,
+                meta: None,
+            }),
+        )
+        .await?;
+
+        self.send_update(
+            &session_id,
+            acp::SessionUpdate::ToolCallUpdate(acp::ToolCallUpdate {
+                id: tool_id.clone(),
+                fields: acp::ToolCallUpdateFields {
+                    status: Some(acp::ToolCallStatus::Completed),
+                    content: Some(vec![acp::ToolCallContent::from(format!(
+                        "Summary created for: {summary}"
+                    ))]),
+                    title: Some("Generated summary".into()),
+                    ..Default::default()
+                },
+                meta: None,
+            }),
+        )
+        .await?;
+
+        self.send_update(
+            &session_id,
+            acp::SessionUpdate::CurrentModeUpdate {
+                current_mode_id: acp::SessionModeId("writer".into()),
+            },
+        )
+        .await?;
+
+        self.send_update(
+            &session_id,
+            acp::SessionUpdate::AgentMessageChunk {
+                content: "Here is your concise summary.".into(),
+            },
+        )
+        .await?;
+
+        sleep(Duration::from_millis(50)).await;
+
+        Ok(acp::PromptResponse {
+            stop_reason: acp::StopReason::EndTurn,
+            meta: None,
+        })
+    }
+
+    async fn cancel(&self, _: acp::CancelNotification) -> std::result::Result<(), acp::Error> {
+        Ok(())
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let outgoing = tokio::io::stdout().compat_write();
+    let incoming = tokio::io::stdin().compat();
+
+    let local_set = tokio::task::LocalSet::new();
+    local_set
+        .run_until(async move {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+            let (connection, io_task) =
+                acp::AgentSideConnection::new(MockAgent::new(tx), outgoing, incoming, |fut| {
+                    tokio::task::spawn_local(fut);
+                });
+
+            tokio::task::spawn_local(async move {
+                while let Some((notification, ack)) = rx.recv().await {
+                    if connection.session_notification(notification).await.is_err() {
+                        break;
+                    }
+                    let _ = ack.send(());
+                }
+            });
+
+            io_task.await
+        })
+        .await?;
+    Ok(())
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,308 @@
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use assert_cmd::cargo::cargo_bin;
+use serde_json::Value;
+use tempfile::TempDir;
+use tokio::{
+    fs,
+    io::AsyncWriteExt,
+    process::{Child, Command},
+    time::{Instant, sleep},
+};
+
+struct DaemonHandle {
+    socket_path: PathBuf,
+    _tempdir: TempDir,
+    child: Child,
+}
+
+impl DaemonHandle {
+    async fn spawn() -> Result<Self> {
+        let kakoune_acp = cargo_bin("kakoune-acp");
+        let agent = cargo_bin("mock-acp-agent");
+        let tempdir = TempDir::new()?;
+        let socket_path = tempdir.path().join("daemon.sock");
+
+        let child = Command::new(&kakoune_acp)
+            .arg("daemon")
+            .arg("--socket")
+            .arg(&socket_path)
+            .arg("--cwd")
+            .arg(tempdir.path())
+            .arg("--")
+            .arg(&agent)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .context("failed to spawn kakoune-acp daemon")?;
+
+        wait_for_socket(&socket_path).await?;
+
+        Ok(Self {
+            socket_path,
+            _tempdir: tempdir,
+            child,
+        })
+    }
+
+    fn socket_path(&self) -> &PathBuf {
+        &self.socket_path
+    }
+
+    fn working_dir(&self) -> &Path {
+        self._tempdir.path()
+    }
+
+    async fn shutdown(mut self) -> Result<()> {
+        let kakoune_acp = cargo_bin("kakoune-acp");
+        let shutdown_status = Command::new(&kakoune_acp)
+            .arg("shutdown")
+            .arg("--socket")
+            .arg(&self.socket_path)
+            .status()
+            .await
+            .context("failed to send shutdown request")?;
+
+        if !shutdown_status.success() {
+            let _ = self.child.start_kill();
+        }
+
+        match tokio::time::timeout(Duration::from_secs(5), self.child.wait()).await {
+            Ok(waited) => {
+                let _ = waited.context("failed to wait for daemon shutdown")?;
+            }
+            Err(_) => {
+                let _ = self.child.start_kill();
+                let _ = self.child.wait().await;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+async fn wait_for_socket(path: &Path) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if fs::try_exists(path).await? {
+            break;
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("socket {} was not created in time", path.display());
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    Ok(())
+}
+
+async fn run_status(socket_path: &Path) -> Result<Value> {
+    let kakoune_acp = cargo_bin("kakoune-acp");
+    let output = Command::new(&kakoune_acp)
+        .arg("status")
+        .arg("--socket")
+        .arg(socket_path)
+        .arg("--json")
+        .output()
+        .await
+        .context("failed to query daemon status")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "status command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status_json: Value = serde_json::from_slice(&output.stdout)
+        .context("failed to parse status response as JSON")?;
+    Ok(status_json)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prompt_transcript_workflows() -> Result<()> {
+    let daemon = DaemonHandle::spawn().await?;
+    let socket_path = daemon.socket_path().clone();
+
+    let status = run_status(&socket_path).await?;
+    assert_eq!(status["running"], Value::Bool(true));
+    assert!(status["session_id"].is_string());
+
+    let plain_context = daemon.working_dir().join("context.txt");
+    tokio::fs::write(&plain_context, "Important context from the project").await?;
+
+    let kakoune_acp = cargo_bin("kakoune-acp");
+    let plain_output = Command::new(&kakoune_acp)
+        .arg("prompt")
+        .arg("--socket")
+        .arg(&socket_path)
+        .arg("--prompt")
+        .arg("Summarise the important context")
+        .arg("--context-file")
+        .arg(&plain_context)
+        .arg("--output")
+        .arg("plain")
+        .output()
+        .await
+        .context("failed to run plain prompt command")?;
+
+    anyhow::ensure!(
+        plain_output.status.success(),
+        "plain prompt failed: {}",
+        String::from_utf8_lossy(&plain_output.stderr)
+    );
+
+    let plain_stdout = String::from_utf8(plain_output.stdout)
+        .context("plain prompt output was not valid UTF-8")?;
+    assert!(plain_stdout.contains("=== Prompt ==="));
+    assert!(plain_stdout.contains("Summarise the important context"));
+    assert!(plain_stdout.contains("=== Context ==="));
+    assert!(plain_stdout.contains("apply_suggestion"));
+    assert!(plain_stdout.contains("[plan]"));
+    assert!(plain_stdout.contains("[commands]"));
+    assert!(plain_stdout.contains("[thought] Thinking about"));
+    assert!(plain_stdout.contains("[tool write_summary] Completed"));
+    assert!(plain_stdout.contains("[system] Current mode: writer"));
+    assert!(plain_stdout.contains("Stop reason: EndTurn"));
+
+    let json_context = daemon.working_dir().join("notes.txt");
+    tokio::fs::write(&json_context, "Streamed context snippet").await?;
+
+    let json_output = Command::new(&kakoune_acp)
+        .arg("prompt")
+        .arg("--socket")
+        .arg(&socket_path)
+        .arg("--prompt")
+        .arg("Explain how the daemon collected transcript events")
+        .arg("--context-file")
+        .arg(&json_context)
+        .arg("--output")
+        .arg("json")
+        .output()
+        .await
+        .context("failed to run json prompt command")?;
+
+    anyhow::ensure!(
+        json_output.status.success(),
+        "json prompt failed: {}",
+        String::from_utf8_lossy(&json_output.stderr)
+    );
+
+    let json_stdout =
+        String::from_utf8(json_output.stdout).context("json prompt output was not valid UTF-8")?;
+    let result_json: Value =
+        serde_json::from_str(&json_stdout).context("invalid JSON from prompt output")?;
+    assert_eq!(
+        result_json["user_prompt"],
+        "Explain how the daemon collected transcript events"
+    );
+    assert_eq!(result_json["stop_reason"], "end_turn");
+    assert_eq!(
+        result_json["context"]
+            .as_array()
+            .map(|entries| entries.len()),
+        Some(1)
+    );
+
+    let transcript = result_json["transcript"]
+        .as_array()
+        .context("transcript was not an array")?;
+    assert!(
+        transcript
+            .iter()
+            .any(|event| event["kind"] == "agent_message")
+    );
+    assert!(transcript.iter().any(|event| event["kind"] == "plan"));
+    assert!(transcript.iter().any(|event| event["kind"] == "tool_call"));
+
+    daemon.shutdown().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn prompt_send_to_kak_when_available() -> Result<()> {
+    if !kak_available().await {
+        eprintln!("kak executable not found, skipping integration test");
+        return Ok(());
+    }
+
+    let daemon = DaemonHandle::spawn().await?;
+    let socket_path = daemon.socket_path().clone();
+
+    let session_name = format!("acp-test-{}", std::process::id());
+    let mut kak_process = Command::new("kak")
+        .arg("-ui")
+        .arg("dummy")
+        .arg("-n")
+        .arg(&session_name)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("failed to launch kakoune for send-to-kak test")?;
+
+    sleep(Duration::from_millis(500)).await;
+
+    let kakoune_acp = cargo_bin("kakoune-acp");
+    let output = Command::new(&kakoune_acp)
+        .arg("prompt")
+        .arg("--socket")
+        .arg(&socket_path)
+        .arg("--prompt")
+        .arg("Send this transcript into Kakoune")
+        .arg("--output")
+        .arg("plain")
+        .arg("--send-to-kak")
+        .arg("--session")
+        .arg(&session_name)
+        .arg("--title")
+        .arg("ACP test transcript")
+        .output()
+        .await
+        .context("failed to run prompt with send-to-kak")?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "prompt command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    send_to_kak(&session_name, "quit").await?;
+    let _ = tokio::time::timeout(Duration::from_secs(5), kak_process.wait()).await;
+
+    daemon.shutdown().await
+}
+
+async fn kak_available() -> bool {
+    Command::new("kak")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+async fn send_to_kak(session: &str, command: &str) -> Result<()> {
+    let mut process = Command::new("kak")
+        .arg("-p")
+        .arg(session)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .with_context(|| format!("failed to connect to kak session {session}"))?;
+
+    if let Some(mut stdin) = process.stdin.take() {
+        stdin
+            .write_all(format!("{command}\n").as_bytes())
+            .await
+            .context("failed to write command to kak session")?;
+    }
+
+    let status = process
+        .wait()
+        .await
+        .context("failed to wait for kak -p command")?;
+    anyhow::ensure!(status.success(), "kak -p exited with status {status}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add a mock ACP agent binary that streams representative session updates
- write an integration test that exercises plain, JSON, and Kakoune prompt flows
- wire up the new test dependencies required to run the scenario

## Testing
- `cargo test --tests`


------
https://chatgpt.com/codex/tasks/task_e_68e08a5dfeb88322b712e3c80410d83b