### PR TITLE
Expand integration tests for Kakoune command handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +158,17 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bytes"
@@ -217,10 +244,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "event-listener"
@@ -242,6 +291,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "futures"
@@ -333,6 +388,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,10 +440,12 @@ version = "0.1.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "clap",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
@@ -394,6 +463,12 @@ name = "libc"
 version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -441,7 +516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
@@ -517,6 +592,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +635,12 @@ checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
@@ -585,6 +693,19 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "ryu"
@@ -735,6 +856,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,10 +1007,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "windows-link"
@@ -1033,3 +1200,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,12 @@ tokio = { version = "1.47", features = [
     "sync",
     "signal",
     "io-std",
+    "time",
 ] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+tempfile = "3.13"

--- a/examples/mock_agent.rs
+++ b/examples/mock_agent.rs
@@ -1,0 +1,315 @@
+use std::cell::Cell;
+
+use agent_client_protocol::{
+    self as acp, Agent, AvailableCommand, AvailableCommandInput, Client, Plan, PlanEntry,
+    PlanEntryPriority, PlanEntryStatus, SessionMode, SessionModeId, SessionModeState,
+    SessionNotification, SessionUpdate, StopReason, ToolCall, ToolCallContent, ToolCallId,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
+};
+use anyhow::Result;
+use serde_json::json;
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::yield_now,
+    time::{Duration, sleep},
+};
+use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
+
+struct MockAgent {
+    session_update_tx: mpsc::UnboundedSender<(SessionNotification, oneshot::Sender<()>)>,
+    next_session_id: Cell<u64>,
+}
+
+impl MockAgent {
+    fn new(
+        session_update_tx: mpsc::UnboundedSender<(SessionNotification, oneshot::Sender<()>)>,
+    ) -> Self {
+        Self {
+            session_update_tx,
+            next_session_id: Cell::new(0),
+        }
+    }
+
+    async fn send_update(
+        &self,
+        session_id: acp::SessionId,
+        update: SessionUpdate,
+    ) -> Result<(), acp::Error> {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        self.session_update_tx
+            .send((
+                SessionNotification {
+                    session_id,
+                    update,
+                    meta: None,
+                },
+                ack_tx,
+            ))
+            .map_err(|_| acp::Error::internal_error())?;
+        ack_rx.await.map_err(|_| acp::Error::internal_error())?;
+        yield_now().await;
+        sleep(Duration::from_millis(10)).await;
+        Ok(())
+    }
+}
+
+fn render_content(block: &acp::ContentBlock) -> String {
+    match block {
+        acp::ContentBlock::Text(text) => text.text.clone(),
+        acp::ContentBlock::Image(image) => image
+            .uri
+            .clone()
+            .unwrap_or_else(|| format!("<image:{}>", image.mime_type)),
+        acp::ContentBlock::Audio(audio) => format!("<audio:{}>", audio.mime_type),
+        acp::ContentBlock::ResourceLink(link) => link
+            .description
+            .clone()
+            .or_else(|| link.title.clone())
+            .or_else(|| Some(link.name.clone()))
+            .unwrap_or_else(|| link.uri.clone()),
+        acp::ContentBlock::Resource(resource) => match &resource.resource {
+            acp::EmbeddedResourceResource::TextResourceContents(text) => text.text.clone(),
+            acp::EmbeddedResourceResource::BlobResourceContents(blob) => {
+                format!("<resource:{}>", blob.uri)
+            }
+        },
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl Agent for MockAgent {
+    async fn initialize(
+        &self,
+        _arguments: acp::InitializeRequest,
+    ) -> Result<acp::InitializeResponse, acp::Error> {
+        Ok(acp::InitializeResponse {
+            protocol_version: acp::V1,
+            agent_capabilities: acp::AgentCapabilities::default(),
+            auth_methods: Vec::new(),
+            meta: None,
+        })
+    }
+
+    async fn authenticate(
+        &self,
+        _arguments: acp::AuthenticateRequest,
+    ) -> Result<acp::AuthenticateResponse, acp::Error> {
+        Ok(acp::AuthenticateResponse::default())
+    }
+
+    async fn new_session(
+        &self,
+        _arguments: acp::NewSessionRequest,
+    ) -> Result<acp::NewSessionResponse, acp::Error> {
+        let session_id = self.next_session_id.get();
+        self.next_session_id.set(session_id + 1);
+        Ok(acp::NewSessionResponse {
+            session_id: acp::SessionId(session_id.to_string().into()),
+            modes: Some(SessionModeState {
+                current_mode_id: SessionModeId("demo-mode".into()),
+                available_modes: vec![SessionMode {
+                    id: SessionModeId("demo-mode".into()),
+                    name: "Demo Mode".into(),
+                    description: Some("A lightweight mode that streams rich updates.".into()),
+                    meta: None,
+                }],
+                meta: None,
+            }),
+            meta: Some(json!({ "workspace": "mock" })),
+        })
+    }
+
+    async fn prompt(
+        &self,
+        arguments: acp::PromptRequest,
+    ) -> Result<acp::PromptResponse, acp::Error> {
+        let session_id = arguments.session_id.clone();
+        let mut blocks = arguments.prompt.iter();
+        let user_prompt = blocks
+            .next()
+            .map(render_content)
+            .unwrap_or_else(|| "<empty prompt>".into());
+        let context_snippets: Vec<String> = blocks.map(render_content).collect();
+
+        self.send_update(
+            session_id.clone(),
+            SessionUpdate::UserMessageChunk {
+                content: format!("{user_prompt}").into(),
+            },
+        )
+        .await?;
+        self.send_update(
+            session_id.clone(),
+            SessionUpdate::AgentThoughtChunk {
+                content: format!(
+                    "Analysing {} context snippets for `{user_prompt}`",
+                    context_snippets.len()
+                )
+                .into(),
+            },
+        )
+        .await?;
+        self.send_update(
+            session_id.clone(),
+            SessionUpdate::Plan(Plan {
+                entries: vec![
+                    PlanEntry {
+                        content: "Understand the prompt".into(),
+                        priority: PlanEntryPriority::High,
+                        status: PlanEntryStatus::InProgress,
+                        meta: None,
+                    },
+                    PlanEntry {
+                        content: "Synthesize a response".into(),
+                        priority: PlanEntryPriority::Medium,
+                        status: PlanEntryStatus::Pending,
+                        meta: None,
+                    },
+                ],
+                meta: None,
+            }),
+        )
+        .await?;
+        self.send_update(
+            session_id.clone(),
+            SessionUpdate::AvailableCommandsUpdate {
+                available_commands: vec![AvailableCommand {
+                    name: "refine_response".into(),
+                    description: "Ask the agent to iterate on the generated answer".into(),
+                    input: Some(AvailableCommandInput::Unstructured {
+                        hint: "Describe the additional detail you need".into(),
+                    }),
+                    meta: None,
+                }],
+            },
+        )
+        .await?;
+
+        let tool_id = ToolCallId("demo-tool".into());
+        self.send_update(
+            session_id.clone(),
+            SessionUpdate::ToolCall(ToolCall {
+                id: tool_id.clone(),
+                title: "Simulate execution".into(),
+                kind: acp::ToolKind::Execute,
+                status: ToolCallStatus::InProgress,
+                content: Vec::new(),
+                locations: Vec::new(),
+                raw_input: Some(json!({
+                    "prompt": user_prompt,
+                    "context": context_snippets,
+                })),
+                raw_output: None,
+                meta: None,
+            }),
+        )
+        .await?;
+        self.send_update(
+            session_id.clone(),
+            SessionUpdate::ToolCallUpdate(ToolCallUpdate {
+                id: tool_id.clone(),
+                fields: ToolCallUpdateFields {
+                    status: Some(ToolCallStatus::Completed),
+                    content: Some(vec![ToolCallContent::from(
+                        "Executed synthetic task for the prompt",
+                    )]),
+                    ..Default::default()
+                },
+                meta: None,
+            }),
+        )
+        .await?;
+        self.send_update(
+            session_id.clone(),
+            SessionUpdate::CurrentModeUpdate {
+                current_mode_id: SessionModeId("demo-mode".into()),
+            },
+        )
+        .await?;
+        self.send_update(
+            session_id.clone(),
+            SessionUpdate::AgentMessageChunk {
+                content: "I am preparing your answer.".into(),
+            },
+        )
+        .await?;
+        self.send_update(
+            session_id,
+            SessionUpdate::AgentMessageChunk {
+                content: format!(
+                    "Processed `{user_prompt}` with {} extra snippets.",
+                    arguments.prompt.len().saturating_sub(1)
+                )
+                .into(),
+            },
+        )
+        .await?;
+
+        Ok(acp::PromptResponse {
+            stop_reason: StopReason::EndTurn,
+            meta: Some(json!({
+                "context_snippets": arguments.prompt.len().saturating_sub(1),
+            })),
+        })
+    }
+
+    async fn cancel(&self, _args: acp::CancelNotification) -> Result<(), acp::Error> {
+        Ok(())
+    }
+
+    async fn load_session(
+        &self,
+        _args: acp::LoadSessionRequest,
+    ) -> Result<acp::LoadSessionResponse, acp::Error> {
+        Ok(acp::LoadSessionResponse {
+            modes: Some(SessionModeState {
+                current_mode_id: SessionModeId("demo-mode".into()),
+                available_modes: vec![SessionMode {
+                    id: SessionModeId("demo-mode".into()),
+                    name: "Demo Mode".into(),
+                    description: Some("Mock agent load stub".into()),
+                    meta: None,
+                }],
+                meta: None,
+            }),
+            meta: None,
+        })
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let outgoing = tokio::io::stdout().compat_write();
+    let incoming = tokio::io::stdin().compat();
+
+    let local_set = tokio::task::LocalSet::new();
+    local_set
+        .run_until(async move {
+            let (tx, mut rx) = mpsc::unbounded_channel();
+            let (conn, io_task) = acp::AgentSideConnection::new(
+                MockAgent::new(tx.clone()),
+                outgoing,
+                incoming,
+                |fut| {
+                    tokio::task::spawn_local(fut);
+                },
+            );
+
+            tokio::task::spawn_local(async move {
+                while let Some((notification, ack)) = rx.recv().await {
+                    let result = conn.session_notification(notification).await;
+                    if let Err(err) = result {
+                        eprintln!("mock agent failed to send notification: {err}");
+                        let _ = ack.send(());
+                        break;
+                    }
+                    let _ = ack.send(());
+                }
+            });
+
+            io_task.await
+        })
+        .await?;
+
+    Ok(())
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,0 +1,440 @@
+#![cfg(unix)]
+
+use std::{
+    env, fs,
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Child, Command, Output, Stdio},
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use assert_cmd::cargo::cargo_bin;
+use serde_json::Value;
+use tempfile::TempDir;
+
+struct TestHarness {
+    tempdir: TempDir,
+    socket_path: PathBuf,
+    binary_path: PathBuf,
+    child: Child,
+}
+
+fn mock_agent_path() -> Result<PathBuf> {
+    static CACHE: OnceLock<PathBuf> = OnceLock::new();
+    if let Some(path) = CACHE.get() {
+        return Ok(path.clone());
+    }
+
+    let status = Command::new("cargo")
+        .args(["build", "--example", "mock_agent"])
+        .status()
+        .context("failed to build mock_agent example")?;
+    if !status.success() {
+        bail!("cargo build --example mock_agent exited with {status}");
+    }
+
+    let target_dir = env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into());
+    let built_path = PathBuf::from(target_dir)
+        .join("debug")
+        .join("examples")
+        .join(format!("mock_agent{}", env::consts::EXE_SUFFIX));
+    let absolute = fs::canonicalize(&built_path)
+        .with_context(|| format!("failed to canonicalize {}", built_path.display()))?;
+    Ok(CACHE.get_or_init(|| absolute).clone())
+}
+
+impl TestHarness {
+    fn new() -> Result<Self> {
+        let agent_path = mock_agent_path()?;
+        let tempdir = tempfile::tempdir()?;
+        let socket_path = tempdir.path().join("daemon.sock");
+        let binary_path = cargo_bin("kakoune-acp");
+
+        let mut command = Command::new(&binary_path);
+        command
+            .arg("daemon")
+            .arg("--socket")
+            .arg(&socket_path)
+            .arg("--cwd")
+            .arg(tempdir.path())
+            .arg("--")
+            .arg(agent_path)
+            .current_dir(tempdir.path())
+            .env_remove("RUST_LOG")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        let mut child = command.spawn().context("failed to spawn daemon")?;
+        wait_for_socket(&mut child, &socket_path)?;
+
+        Ok(Self {
+            tempdir,
+            socket_path,
+            binary_path,
+            child,
+        })
+    }
+
+    fn workspace(&self) -> &Path {
+        self.tempdir.path()
+    }
+
+    fn socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    fn cli_command(&self) -> Command {
+        let mut command = Command::new(&self.binary_path);
+        command.current_dir(self.workspace()).env_remove("RUST_LOG");
+        command
+    }
+
+    fn prompt_command(&self) -> Command {
+        let mut command = self.cli_command();
+        command
+            .arg("prompt")
+            .arg("--socket")
+            .arg(self.socket_path());
+        command
+    }
+
+    fn status_command(&self) -> Command {
+        let mut command = self.cli_command();
+        command
+            .arg("status")
+            .arg("--socket")
+            .arg(self.socket_path());
+        command
+    }
+
+    fn shutdown(mut self) -> Result<Output> {
+        let mut command = Command::new(&self.binary_path);
+        command
+            .current_dir(self.workspace())
+            .env_remove("RUST_LOG")
+            .arg("shutdown")
+            .arg("--socket")
+            .arg(&self.socket_path);
+        let output = command.output().context("failed to run shutdown command")?;
+        let _ = output.status;
+        let _ = self.child.wait();
+        Ok(output)
+    }
+}
+
+impl Drop for TestHarness {
+    fn drop(&mut self) {
+        if let Ok(None) = self.child.try_wait() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn wait_for_socket(child: &mut Child, socket: &Path) -> Result<()> {
+    let start = Instant::now();
+    let timeout = Duration::from_secs(10);
+    while start.elapsed() < timeout {
+        if socket.exists() {
+            return Ok(());
+        }
+        if let Some(status) = child
+            .try_wait()
+            .context("failed to poll daemon process state")?
+        {
+            bail!("daemon exited before creating socket with status {status}");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    Err(anyhow!("daemon did not create socket within {timeout:?}"))
+}
+
+fn require_success(context: &str, output: Output) -> Result<String> {
+    if !output.status.success() {
+        bail!(
+            "{context} failed: status={}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let stdout = String::from_utf8(output.stdout)?;
+    if !output.stderr.is_empty() {
+        eprintln!(
+            "{context} emitted stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(stdout)
+}
+
+fn find_in_path(program: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for entry in std::env::split_paths(&path_var) {
+        let candidate = entry.join(program);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn wait_for_kak_session(kak: &Path, session: &str, timeout: Duration) -> Result<bool> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        let output = Command::new(kak)
+            .arg("-l")
+            .output()
+            .context("failed to list kakoune sessions")?;
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout.lines().any(|line| line.trim() == session) {
+                return Ok(true);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    Ok(false)
+}
+
+fn send_kak_command(kak: &Path, session: &str, command: &str) -> Result<()> {
+    let mut child = Command::new(kak)
+        .arg("-p")
+        .arg(session)
+        .stdin(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to send command to kakoune session {session}"))?;
+    child
+        .stdin
+        .as_mut()
+        .context("kakoune pipe stdin missing")?
+        .write_all(command.as_bytes())?;
+    child.stdin.as_mut().unwrap().write_all(b"\n")?;
+    let status = child.wait()?;
+    if !status.success() {
+        bail!("kak -p exited with status {status}");
+    }
+    Ok(())
+}
+
+#[test]
+fn prompt_json_transcript_includes_rich_events() -> Result<()> {
+    let harness = TestHarness::new()?;
+    let context_file = harness.workspace().join("context.md");
+    std::fs::write(&context_file, "Remember to highlight the tool calls.\n")?;
+
+    let output = harness
+        .prompt_command()
+        .arg("--prompt")
+        .arg("Summarise the integration behaviour")
+        .arg("--context")
+        .arg("Focus on plan and tool call events")
+        .arg("--context-file")
+        .arg(&context_file)
+        .arg("--output")
+        .arg("json")
+        .output()
+        .context("failed to run prompt command")?;
+    let stdout = require_success("prompt json", output)?;
+
+    let result: Value = serde_json::from_str(stdout.trim()).context("invalid json output")?;
+    assert_eq!(result["stop_reason"], "end_turn");
+
+    let context = result["context"].as_array().context("context missing")?;
+    assert_eq!(context.len(), 2);
+    assert_eq!(context[0]["text"], "Focus on plan and tool call events");
+    assert!(context[1]["label"].as_str().unwrap().contains("context.md"));
+
+    let transcript = result["transcript"]
+        .as_array()
+        .context("transcript missing")?;
+    assert!(
+        transcript
+            .iter()
+            .any(|event| event["kind"] == "user_message")
+    );
+    assert!(
+        transcript
+            .iter()
+            .any(|event| event["kind"] == "agent_thought"),
+        "transcript missing agent_thought: {:?}",
+        transcript
+    );
+    assert!(transcript.iter().any(|event| event["kind"] == "plan"));
+    assert!(
+        transcript
+            .iter()
+            .any(|event| event["kind"] == "available_commands")
+    );
+    assert!(transcript.iter().any(|event| event["kind"] == "tool_call"));
+    assert!(
+        transcript
+            .iter()
+            .any(|event| event["kind"] == "tool_call_update")
+    );
+    assert!(
+        transcript
+            .iter()
+            .any(|event| event["kind"] == "system_message")
+    );
+    assert!(
+        transcript
+            .iter()
+            .any(|event| event["kind"] == "agent_message")
+    );
+
+    harness.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn prompt_plain_output_renders_sections() -> Result<()> {
+    let harness = TestHarness::new()?;
+    let output = harness
+        .prompt_command()
+        .arg("--prompt")
+        .arg("Show me plain formatting")
+        .arg("--context")
+        .arg("Plain mode context")
+        .output()
+        .context("failed to run prompt command")?;
+    let stdout = require_success("prompt plain", output)?;
+
+    assert!(stdout.contains("=== Prompt ==="));
+    assert!(stdout.contains("[agent]"));
+    assert!(stdout.contains("[thought]"));
+    assert!(stdout.contains("[plan]"));
+    assert!(stdout.contains("[commands]"));
+    assert!(stdout.contains("[tool demo-tool]"));
+
+    harness.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn prompt_kak_commands_output_wraps_in_info_command() -> Result<()> {
+    let harness = TestHarness::new()?;
+    let context_file = harness.workspace().join("context.txt");
+    std::fs::write(&context_file, "Context from file\n")?;
+
+    let output = harness
+        .prompt_command()
+        .arg("--prompt")
+        .arg("Render kak commands")
+        .arg("--context-file")
+        .arg(&context_file)
+        .arg("--output")
+        .arg("kak-commands")
+        .arg("--title")
+        .arg("Integration Title")
+        .arg("--client")
+        .arg("main")
+        .output()
+        .context("failed to run prompt command with kak-commands output")?;
+    let stdout = require_success("prompt kak-commands", output)?;
+
+    assert!(stdout.starts_with("eval -client 'main' %{"));
+    assert!(stdout.contains("info -title 'Integration Title'"));
+    assert!(stdout.contains("=== Prompt ==="));
+    assert!(stdout.contains("Render kak commands"));
+    assert!(stdout.contains("[1] file:"));
+
+    harness.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn daemon_status_and_shutdown_roundtrip() -> Result<()> {
+    let harness = TestHarness::new()?;
+    let status_output = harness
+        .status_command()
+        .arg("--json")
+        .output()
+        .context("failed to run status command")?;
+    let stdout = require_success("status json", status_output)?;
+    let status: Value = serde_json::from_str(stdout.trim()).context("invalid status json")?;
+    assert_eq!(status["running"], true);
+    assert!(status["session_id"].as_str().is_some());
+
+    let shutdown_output = harness.shutdown()?;
+    let message = require_success("shutdown", shutdown_output)?;
+    assert!(message.contains("daemon shut down"));
+
+    Ok(())
+}
+
+#[test]
+fn prompt_send_to_kak_requires_session() -> Result<()> {
+    let harness = TestHarness::new()?;
+    let output = harness
+        .prompt_command()
+        .arg("--prompt")
+        .arg("trigger send to kak")
+        .arg("--send-to-kak")
+        .output()
+        .context("failed to run prompt command with send-to-kak")?;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("requires a Kakoune session"));
+
+    harness.shutdown()?;
+    Ok(())
+}
+
+#[test]
+fn prompt_can_send_to_running_kakoune_session() -> Result<()> {
+    let Some(kak_path) = find_in_path("kak") else {
+        eprintln!("skipping kakoune integration test because kak is not available");
+        return Ok(());
+    };
+
+    let harness = TestHarness::new()?;
+    let session_name = format!("acp-test-{}", std::process::id());
+    let mut kak_command = Command::new(&kak_path);
+    if std::env::var_os("KAKOUNE_ACP_UI_TEST").is_none() {
+        kak_command.arg("-n");
+    }
+    kak_command.arg("-s").arg(&session_name);
+
+    let mut kak_child = match kak_command.spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            eprintln!("skipping kakoune integration test: failed to launch kak: {err}");
+            harness.shutdown()?;
+            return Ok(());
+        }
+    };
+
+    if !wait_for_kak_session(&kak_path, &session_name, Duration::from_secs(3))? {
+        eprintln!(
+            "skipping kakoune integration test: session {session_name} did not become available"
+        );
+        let _ = kak_child.kill();
+        let _ = kak_child.wait();
+        harness.shutdown()?;
+        return Ok(());
+    }
+
+    let output = harness
+        .prompt_command()
+        .arg("--prompt")
+        .arg("Display integration status")
+        .arg("--session")
+        .arg(&session_name)
+        .arg("--title")
+        .arg("ACP integration")
+        .arg("--send-to-kak")
+        .output()
+        .context("failed to run prompt with send-to-kak")?;
+    let stdout = require_success("prompt send-to-kak", output)?;
+    assert!(stdout.contains("=== Prompt ==="));
+
+    let _ = send_kak_command(&kak_path, &session_name, "quit!");
+    let _ = kak_child.wait();
+    harness.shutdown()?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- extend the end-to-end suite with coverage for the `--output kak-commands` format
- add a regression test ensuring `--send-to-kak` requires a session binding

## Testing
- cargo test -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e08a5dfeb88322b712e3c80410d83b